### PR TITLE
Manually set the hasCredentials property on IceServers, provide a freeice example

### DIFF
--- a/examples/temasys-freeice.js
+++ b/examples/temasys-freeice.js
@@ -1,0 +1,18 @@
+var RTC = require('rtc');
+var crel = require('crel');
+var freeice = require('freeice');
+var temasys = require('..');
+
+document.body.appendChild(crel('div', crel('div', { id: 'l-video' }), crel('div', { id: 'r-video'})));
+
+var call = RTC({
+  constraints: {
+    audio: true,
+    video: true
+  },
+  ice: freeice(),
+  plugins: [
+    temasys
+  ],
+  options: {}
+});

--- a/index.js
+++ b/index.js
@@ -143,9 +143,17 @@ exports.createIceCandidate = function(opts) {
 };
 
 exports.createConnection = function(config, constraints) {
+  var iceServers = ((config || {}).iceServers || []).map(function(iceServer) {
+    // The Temasys plugin creates a null `hasCredentials` property if it is not explicitly
+    // set, which then throws an exception as it cannot cast it's value. So set the value
+    // manually
+    iceServer.hasCredentials = !!iceServer.credential;
+    return iceServer;
+  });
+  
   return loader.plugin && loader.plugin.PeerConnection(
     loader.pageId,
-    (config || {}).iceServers || [],
+    iceServers,
     (constraints || {}).mandatory || null,
     (constraints || {}).optional || null
   );

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   },
   "devDependencies": {
     "cog": "^1.0.0",
+    "freeice": "^2.2.0",
+    "rtc": "^3.3.0",
     "rtc-attach": "^2.0.1",
     "rtc-capture": "^1.0.0",
     "rtc-media": "^2.0.1",


### PR DESCRIPTION
This should fix issue #3, and hopefully #4 - with the Temasys plugin throwing type cast errors.

These errors seem to be caused by the Temasys plugin internally assigning a non standard `hasCredentials` property to each of the specified ICE server objects, and in the case of no credentials, assigning the value of this property to `null` - which then promptly fails their internal typecasting.

By predetermining, and assigning the `hasCredentials` property, it seems to get around the issue of Temasys doing a poor job on it's own.
